### PR TITLE
Add farm purchase and random event mechanics

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,13 @@
+# Sugoroku Farm Backend
+
+This service provides the API for the Sugoroku Farm game. In addition to
+planting and harvesting crops, players can now purchase a **farm** tile.
+
+* The farm is located at position defined by `FARM_POS` on the board.
+* Landing on that tile allows a player to buy the farm for **100 coins** via
+  `POST /game/{game_id}/buy-farm`.
+* Owners receive random profit or loss events each turn, while players without
+  a farm experience neutral events.
+
+These mechanics are exposed through the standard FastAPI endpoints used by the
+frontend application.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -37,6 +37,10 @@ class Square(BaseModel):
     id: int
     crop: Optional[Crop] = None
     owner: Optional[str] = None
+    # Whether this square represents the special farm tile
+    is_farm: bool = False
+    # ID of the player who purchased the farm
+    farm_owner: Optional[str] = None
 
 class Player(BaseModel):
     id: str
@@ -44,6 +48,8 @@ class Player(BaseModel):
     position: int
     coins: int
     crops_harvested: int
+    # Indicates whether the player owns the farm
+    has_farm: bool = False
 
 class GameState(BaseModel):
     players: List[Player]
@@ -54,8 +60,12 @@ class GameState(BaseModel):
 
 games: Dict[str, GameState] = {}
 
+# Position on the board that represents the farm
+FARM_POS = 5
+
 def create_board() -> List[Square]:
-    return [Square(id=i) for i in range(20)]
+    """Create the game board with a single farm tile."""
+    return [Square(id=i, is_farm=(i == FARM_POS)) for i in range(20)]
 
 def get_crop_growth_time(crop_type: CropType) -> int:
     growth_times = {
@@ -77,6 +87,13 @@ def get_crop_value(crop_type: CropType) -> int:
 
 
 def trigger_random_event(player: Player) -> str:
+    """Trigger a random farm-related event.
+
+    Players without a farm receive a neutral message with no coin change.
+    """
+    if not player.has_farm:
+        return f"{player.name}: 牧場を持っていないので特に何も起こらなかった"
+
     events = [
         ("牧場経営が順調！利益が出た", 30),
         ("家畜の世話で出費がかさんだ", -20),
@@ -123,6 +140,7 @@ async def roll_dice(game_id: str):
 
     game = games[game_id]
     events: List[str] = []
+    can_buy_farm = False
 
     for _ in range(len(game.players)):
         current_player = game.players[game.current_player]
@@ -132,6 +150,16 @@ async def roll_dice(game_id: str):
 
         new_position = (current_player.position + dice_value) % len(game.board)
         current_player.position = new_position
+        current_square = game.board[current_player.position]
+
+        if (
+            current_square.is_farm
+            and not current_player.has_farm
+            and current_square.farm_owner is None
+            and current_player.id != "bot"
+        ):
+            events.append("牧場に到着！100コインで購入できます")
+            can_buy_farm = True
 
         for square in game.board:
             if square.crop and square.crop.stage != CropStage.READY:
@@ -145,7 +173,6 @@ async def roll_dice(game_id: str):
         events.append(event_msg)
 
         if current_player.id == "bot":
-            current_square = game.board[current_player.position]
             if (
                 current_square.crop
                 and current_square.crop.stage == CropStage.READY
@@ -172,7 +199,39 @@ async def roll_dice(game_id: str):
         game.turn += 1
         game.current_player = (game.current_player + 1) % len(game.players)
 
-    return {"dice_value": game.dice_value, "game_state": game, "events": events}
+    return {
+        "dice_value": game.dice_value,
+        "game_state": game,
+        "events": events,
+        "can_buy_farm": can_buy_farm,
+    }
+
+
+@app.post("/game/{game_id}/buy-farm")
+async def buy_farm(game_id: str):
+    if game_id not in games:
+        raise HTTPException(status_code=404, detail="Game not found")
+
+    game = games[game_id]
+    current_player = game.players[game.current_player]
+    current_square = game.board[current_player.position]
+
+    if not current_square.is_farm:
+        raise HTTPException(status_code=400, detail="This square is not a farm")
+    if current_player.has_farm:
+        raise HTTPException(status_code=400, detail="Player already owns a farm")
+    if current_square.farm_owner is not None:
+        raise HTTPException(status_code=400, detail="Farm already owned")
+
+    cost = 100
+    if current_player.coins < cost:
+        raise HTTPException(status_code=400, detail="Not enough coins")
+
+    current_player.coins -= cost
+    current_player.has_farm = True
+    current_square.farm_owner = current_player.id
+
+    return {"message": "Farm purchased successfully", "game_state": game}
 
 @app.post("/game/{game_id}/plant-crop")
 async def plant_crop(game_id: str, crop_type: CropType):

--- a/backend/tests/test_farm.py
+++ b/backend/tests/test_farm.py
@@ -1,0 +1,39 @@
+import random
+from fastapi.testclient import TestClient
+from app.main import app, games, FARM_POS, Player, trigger_random_event
+
+client = TestClient(app)
+
+def create_game():
+    response = client.post("/game/create", params={"player_name": "Alice"})
+    data = response.json()
+    return data["game_id"]
+
+
+def test_buy_farm():
+    game_id = create_game()
+    game = games[game_id]
+    game.players[0].position = FARM_POS
+
+    res = client.post(f"/game/{game_id}/buy-farm")
+    assert res.status_code == 200
+    data = res.json()
+    player = data["game_state"]["players"][0]
+    square = data["game_state"]["board"][FARM_POS]
+    assert player["has_farm"] is True
+    assert player["coins"] == 0
+    assert square["farm_owner"] == "player1"
+
+
+def test_trigger_random_event_before_after_farm(monkeypatch):
+    monkeypatch.setattr(random, "choice", lambda events: events[0])
+    player = Player(id="p1", name="P1", position=0, coins=100, crops_harvested=0)
+
+    msg_no_farm = trigger_random_event(player)
+    assert "特に何も起こらなかった" in msg_no_farm
+    assert player.coins == 100
+
+    player.has_farm = True
+    msg_with_farm = trigger_random_event(player)
+    assert "利益が出た" in msg_with_farm
+    assert player.coins == 130


### PR DESCRIPTION
## Summary
- Add farm tile with ownership and purchase mechanics on backend
- Support farm ownership and purchase UI on frontend
- Cover farm purchase and event logic with tests

## Testing
- `pytest -q`
- `npm run build` *(fails: Cannot find module '@/lib/utils')*

------
https://chatgpt.com/codex/tasks/task_e_68ae830e33fc8333977492b5253d1f46