### PR TITLE
Add farm ownership mechanics

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -3,7 +3,8 @@
 This service provides the API for the Sugoroku Farm game. In addition to
 planting and harvesting crops, players can now purchase a **farm** tile.
 
-* The farm is located at position defined by `FARM_POS` on the board.
+* When a game is created one random square on the 20-tile board becomes the
+  farm.
 * Landing on that tile allows a player to buy the farm for **100 coins** via
   `POST /game/{game_id}/buy-farm`.
 * Owners receive random profit or loss events each turn, while players without

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -60,12 +60,11 @@ class GameState(BaseModel):
 
 games: Dict[str, GameState] = {}
 
-# Position on the board that represents the farm
-FARM_POS = 5
 
 def create_board() -> List[Square]:
-    """Create the game board with a single farm tile."""
-    return [Square(id=i, is_farm=(i == FARM_POS)) for i in range(20)]
+    """Create the game board with a single farm tile at a random position."""
+    farm_index = random.randint(0, 19)
+    return [Square(id=i, is_farm=(i == farm_index)) for i in range(20)]
 
 def get_crop_growth_time(crop_type: CropType) -> int:
     growth_times = {
@@ -158,7 +157,7 @@ async def roll_dice(game_id: str):
             and current_square.farm_owner is None
             and current_player.id != "bot"
         ):
-            events.append("牧場に到着！100コインで購入できます")
+            events.append("牧場に到着！100コインで契約できます")
             can_buy_farm = True
 
         for square in game.board:

--- a/backend/tests/test_farm.py
+++ b/backend/tests/test_farm.py
@@ -1,6 +1,6 @@
 import random
 from fastapi.testclient import TestClient
-from app.main import app, games, FARM_POS, Player, trigger_random_event
+from app.main import app, games, Player, trigger_random_event
 
 client = TestClient(app)
 
@@ -13,13 +13,14 @@ def create_game():
 def test_buy_farm():
     game_id = create_game()
     game = games[game_id]
-    game.players[0].position = FARM_POS
+    farm_index = next(i for i, sq in enumerate(game.board) if sq.is_farm)
+    game.players[0].position = farm_index
 
     res = client.post(f"/game/{game_id}/buy-farm")
     assert res.status_code == 200
     data = res.json()
     player = data["game_state"]["players"][0]
-    square = data["game_state"]["board"][FARM_POS]
+    square = data["game_state"]["board"][farm_index]
     assert player["has_farm"] is True
     assert player["coins"] == 0
     assert square["farm_owner"] == "player1"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -314,7 +314,7 @@ function App() {
                         disabled={currentPlayer.coins < 100}
                         className="w-full bg-purple-600 hover:bg-purple-700"
                       >
-                        牧場を買う (100コイン)
+                        牧場を契約 (100コイン)
                       </Button>
                     )}
                   </div>


### PR DESCRIPTION
## Summary
- Randomly generate farm tile on game board
- Allow players to contract farm for 100 coins via new endpoint
- Highlight farm purchase in frontend and update docs/tests

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test"*)
- `npm run lint` *(fails: 'actionTypes' is assigned a value but only used as a type)*

------
https://chatgpt.com/codex/tasks/task_e_68af301299d48333afe8bbdaf13044de