### PR TITLE
Add RekoCoin trading and price history graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Sugoroku Farm
+
+This project contains the backend (FastAPI) and frontend (Vite + React) for a simple board game.
+
+## RekoCoin Crypto System
+
+- One board tile is randomly chosen as a crypto exchange.
+- The `crypto_price` changes randomly every turn and a `crypto_history` array is tracked.
+- Players standing on the exchange can buy or sell one RekoCoin using the
+  `/game/{game_id}/buy-reko` and `/game/{game_id}/sell-reko` endpoints.
+
+## Price History Graph
+
+The frontend includes a modal line chart (powered by Recharts) that plots the
+price history of RekoCoin. Use the **価格推移** button in the interface to toggle
+the graph.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,13 +1,18 @@
 # Sugoroku Farm Backend
 
 This service provides the API for the Sugoroku Farm game. In addition to
-planting and harvesting crops, players can now purchase a **farm** tile.
+planting and harvesting crops, players can now purchase a **farm** tile and
+trade the in-game cryptocurrency **RekoCoin**.
 
 * The farm is located at position defined by `FARM_POS` on the board.
 * Landing on that tile allows a player to buy the farm for **100 coins** via
   `POST /game/{game_id}/buy-farm`.
 * Owners receive random profit or loss events each turn, while players without
   a farm experience neutral events.
+* A random tile hosts the crypto exchange where players can buy or sell one
+  RekoCoin using `POST /game/{game_id}/buy-reko` and
+  `POST /game/{game_id}/sell-reko`. The `crypto_price` fluctuates each turn
+  and the full history is exposed as `crypto_history` in the game state.
 
 These mechanics are exposed through the standard FastAPI endpoints used by the
 frontend application.

--- a/backend/tests/test_crypto.py
+++ b/backend/tests/test_crypto.py
@@ -1,0 +1,50 @@
+import random
+from fastapi.testclient import TestClient
+from app.main import app, games
+
+client = TestClient(app)
+
+def create_game():
+    res = client.post("/game/create", params={"player_name": "Alice"})
+    return res.json()["game_id"]
+
+
+def test_buy_sell_reko():
+    game_id = create_game()
+    game = games[game_id]
+    crypto_pos = next(i for i, s in enumerate(game.board) if s.is_crypto_exchange)
+    player = game.players[0]
+    player.position = crypto_pos
+    start_coins = player.coins
+    price = game.crypto_price
+
+    res = client.post(f"/game/{game_id}/buy-reko")
+    assert res.status_code == 200
+    data = res.json()["game_state"]["players"][0]
+    assert data["reko_coin"] == 1
+    assert data["coins"] == start_coins - price
+
+    res = client.post(f"/game/{game_id}/sell-reko")
+    assert res.status_code == 200
+    data = res.json()["game_state"]["players"][0]
+    assert data["reko_coin"] == 0
+    assert data["coins"] == start_coins
+
+
+def test_crypto_price_updates(monkeypatch):
+    game_id = create_game()
+    game = games[game_id]
+    initial_price = game.crypto_price
+
+    def fake_randint(a, b):
+        if (a, b) == (1, 6):
+            return 1
+        if (a, b) == (-5, 5):
+            return 2
+        return a
+
+    monkeypatch.setattr(random, "randint", fake_randint)
+    client.post(f"/game/{game_id}/roll-dice")
+    updated = games[game_id]
+    assert updated.crypto_price == initial_price + 2 * len(updated.players)
+    assert len(updated.crypto_history) == len(updated.players) + 1


### PR DESCRIPTION
## Summary
- add RekoCoin crypto exchange square with buy/sell endpoints
- track crypto price and history in game state and show line chart in UI
- document new crypto system and cover buy/sell logic with tests

## Testing
- `cd backend && pytest`
- `cd frontend && npm test` *(fails: Missing script "test")*
- `cd frontend && npm run lint` *(fails: hooks/use-toast.ts unused var)*

------
https://chatgpt.com/codex/tasks/task_e_68af3046493483339fe06ca06c9ac4df